### PR TITLE
Refresh Ceradon branding and theme

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,6 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
-  <rect width="256" height="256" rx="64" fill="#0b0d10" />
-  <path fill="#1e57c8" d="M128 32 64 56v74c0 52 33.4 90.2 64 94 30.6-3.8 64-42 64-94V56L128 32z" />
-  <path fill="#e7eaee" d="M96 108c16 8 24 12 32 12s16-4 32-12l10 16c-18 10-28 14-42 14s-24-4-42-14l10-16z" opacity="0.85" />
-  <path fill="#b8bdc5" d="M128 70c-16 0-32 6-42 12l10 18c12-8 22-12 32-12s20 4 32 12l10-18c-10-6-26-12-42-12z" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Ceradon Systems Favicon</title>
+  <desc id="desc">Shield crest with Ceradon blue strikes</desc>
+  <defs>
+    <linearGradient id="favShield" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#101728" />
+      <stop offset="100%" stop-color="#05070d" />
+    </linearGradient>
+    <linearGradient id="favEdge" x1="24%" y1="12%" x2="84%" y2="88%">
+      <stop offset="0%" stop-color="#223044" />
+      <stop offset="100%" stop-color="#121a2c" />
+    </linearGradient>
+    <linearGradient id="favStripe" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b78ff" />
+      <stop offset="100%" stop-color="#56b7ff" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="#03050a" />
+  <path d="M64 14 22 32v48c0 46 30 82 42 88 12-6 42-42 42-88V32L64 14z" fill="url(#favShield)" stroke="url(#favEdge)" stroke-width="4" stroke-linejoin="round" />
+  <path d="M64 26 30 40v38c0 34 22 60 34 66 12-6 34-32 34-66V40L64 26z" fill="#0b1220" opacity="0.7" />
+  <path d="M86 52c-4-12-20-22-36-20-16 2-28 14-32 30l10 6c4-12 12-20 22-22 10-2 20 2 24 10l-20 12 28 6 12-10c2-2 2-6-2-12z" fill="#e6ebf5" />
+  <circle cx="76" cy="60" r="4" fill="#07090f" />
+  <circle cx="77" cy="59" r="1.5" fill="#f6f8fd" />
+  <g fill="none" stroke="url(#favStripe)" stroke-linecap="round">
+    <path d="M30 74c16 14 44 18 68 8" stroke-width="8" />
+    <path d="M34 86c16 12 44 14 64 6" stroke-width="6" />
+    <path d="M38 96c14 10 36 12 54 4" stroke-width="5" />
+  </g>
 </svg>

--- a/assets/logo-horizontal.svg
+++ b/assets/logo-horizontal.svg
@@ -1,23 +1,65 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 160" role="img" aria-labelledby="title desc">
-  <title id="title">Ceradon Systems Horizontal Logo</title>
-  <desc id="desc">Shield icon left of Ceradon Systems wordmark</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200" role="img" aria-labelledby="title desc">
+  <title id="title">Ceradon Systems Horizontal Lockup</title>
+  <desc id="desc">Shield crest with Ceradon Systems wordmark</desc>
   <defs>
-    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1e57c8" />
-      <stop offset="100%" stop-color="#0d2d73" />
+    <linearGradient id="shieldBase" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#101728" />
+      <stop offset="100%" stop-color="#05070d" />
+    </linearGradient>
+    <linearGradient id="shieldEdge" x1="30%" y1="10%" x2="90%" y2="90%">
+      <stop offset="0%" stop-color="#223044" />
+      <stop offset="100%" stop-color="#121a2c" />
+    </linearGradient>
+    <linearGradient id="innerGlow" x1="28%" y1="18%" x2="84%" y2="86%">
+      <stop offset="0%" stop-color="#1b2539" />
+      <stop offset="100%" stop-color="#060910" />
+    </linearGradient>
+    <linearGradient id="stripeGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b78ff" />
+      <stop offset="100%" stop-color="#56b7ff" />
+    </linearGradient>
+    <linearGradient id="headFill" x1="32%" y1="12%" x2="72%" y2="88%">
+      <stop offset="0%" stop-color="#f6f8fd" />
+      <stop offset="100%" stop-color="#bac3d5" />
+    </linearGradient>
+    <linearGradient id="headShade" x1="24%" y1="0%" x2="90%" y2="90%">
+      <stop offset="0%" stop-color="#c5cddb" />
+      <stop offset="100%" stop-color="#7f8797" />
     </linearGradient>
   </defs>
-  <rect width="640" height="160" rx="24" fill="#0b0d10" />
-  <g transform="translate(32 24) scale(0.6)">
-    <path fill="url(#shieldGradient)" d="M160 16 64 48v92c0 64.8 41.4 112.6 96 119 54.6-6.4 96-54.2 96-119V48L160 16z" />
-    <path fill="#e7eaee" d="M112 108c26 12 38 16 48 16s22-4 48-16l16 24c-28 14-44 18-64 18s-36-4-64-18l16-24z" opacity="0.85" />
-    <path fill="#b8bdc5" d="M160 56c-24 0-48 8-64 16l14 24c20-10 34-14 50-14s30 4 50 14l14-24c-16-8-40-16-64-16z" />
-    <path fill="#e7eaee" d="M160 156c-14 0-28-3-40-8l-14 22c18 10 36 14 54 14s36-4 54-14l-14-22c-12 5-26 8-40 8z" opacity="0.75" />
+  <rect width="800" height="200" rx="28" fill="#03050a" />
+  <g transform="translate(48 22) scale(0.32)">
+    <path d="M256 32 96 104v164c0 120 82 212 160 240 78-28 160-120 160-240V104L256 32z" fill="url(#shieldBase)" stroke="url(#shieldEdge)" stroke-width="16" stroke-linejoin="round" />
+    <path d="M256 64 128 120v140c0 94 60 176 128 204 68-28 128-110 128-204V120L256 64z" fill="url(#innerGlow)" opacity="0.82" />
+    <g transform="translate(0 -4)">
+      <path d="M360 214c-10-32-32-68-78-90-50-22-122-6-162 46-18 24-26 52-26 80 0 12 2 24 4 34l44 24 18-46c16-38 48-60 88-60 30 0 56 16 66 40l-58 36 88 14 44-34c8-8 10-20-4-32-14-12-24-28-22-34z" fill="url(#headFill)" />
+      <path d="M190 198c18-30 54-48 92-44 34 4 60 22 76 52 4 10 2 20-6 28-32 26-78 40-118 40-42 0-80-12-112-30 0-12 4-30 16-46 16-20 32-32 52-40z" fill="url(#headShade)" opacity="0.45" />
+      <path d="M356 258c-20 8-42 12-64 12-22 0-52-6-80-18l-12 32c42 16 88 20 128 12 26-6 44-16 60-28l-32-10z" fill="#5a6274" opacity="0.35" />
+      <path d="M308 180c-8-10-22-18-36-18-10 0-20 4-30 12 28 2 46 12 58 28l36 18c0-14-12-30-28-40z" fill="#707889" opacity="0.4" />
+      <path d="M352 232c8 10 2 24-10 32-20 12-46 18-74 18-36 0-72-10-96-20 0-12 4-24 10-34 18 12 40 20 62 22 30 2 60-4 84-18 12-8 18-8 24 0z" fill="#eceff6" opacity="0.35" />
+      <path d="M348 268c-28 22-64 34-102 34-42 0-82-12-112-34 2 12 6 22 10 30 32 18 66 28 102 28 38 0 74-12 110-38l-8-20z" fill="#afb7c7" opacity="0.25" />
+      <path d="M360 214c-4-10-12-22-22-32-6 6-18 10-32 10-8 0-16-2-22-4-18-6-36-4-50 4 32 2 60 18 74 40 20 32 12 60-4 78 34-10 60-30 74-52 8-12 8-26 0-44z" fill="#dfe5f1" opacity="0.6" />
+      <path d="M338 208c-4-14-18-24-36-24-14 0-28 6-38 16l-22 22c22 10 46 14 72 12 12-2 22-8 24-16z" fill="#1a2030" opacity="0.45" />
+      <path d="M372 248c-10-10-8-28 6-44 8 10 12 18 14 24 2 10-2 18-10 22l-10-2z" fill="#5c6474" opacity="0.4" />
+      <path d="M330 214c8 4 12 12 10 18-2 6-8 10-16 10-8 0-18-4-28-12 10-12 24-16 34-16z" fill="#151b27" opacity="0.75" />
+      <circle cx="320" cy="214" r="8" fill="#07090f" />
+      <circle cx="322" cy="212" r="3" fill="#f6f8fd" />
+      <path d="M348 234c-10 8-24 14-40 18-18 4-36 4-54 2-22-2-44-10-66-22l-6 16c28 16 58 26 88 28 28 0 54-6 76-18 12-6 20-14 24-22-6-2-14-2-22-2z" fill="#c7cede" opacity="0.35" />
+    </g>
+    <g fill="none" stroke="url(#stripeGradient)" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M132 326c60 48 148 58 228 28" stroke-width="28" opacity="0.85" />
+      <path d="M148 368c54 40 134 48 204 26" stroke-width="24" opacity="0.7" />
+      <path d="M170 408c46 32 110 38 166 22" stroke-width="20" opacity="0.55" />
+    </g>
   </g>
-  <text x="200" y="80" fill="#e7eaee" font-family="'Inter', 'Segoe UI', sans-serif" font-size="56" font-weight="700" letter-spacing="4">
+  <line x1="320" y1="36" x2="320" y2="164" stroke="#202f46" stroke-width="2" opacity="0.6" />
+  <text x="356" y="102" fill="#f4f6fb" font-family="'Inter', 'Segoe UI', sans-serif" font-weight="700" font-size="68" letter-spacing="8">
     CERADON
   </text>
-  <text x="200" y="120" fill="#b8bdc5" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" letter-spacing="8">
+  <text x="356" y="144" fill="#7f889a" font-family="'Inter', 'Segoe UI', sans-serif" font-size="30" letter-spacing="12">
     SYSTEMS
+  </text>
+  <text x="356" y="172" fill="#56b7ff" font-family="'Inter', 'Segoe UI', sans-serif" font-size="16" letter-spacing="6">
+    PASSIVE POSE INTELLIGENCE
   </text>
 </svg>

--- a/assets/logo-mark.svg
+++ b/assets/logo-mark.svg
@@ -1,15 +1,53 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
-  <title id="title">Ceradon Shield Mark</title>
-  <desc id="desc">Shield emblem with stylised eagle wings in Ceradon blue</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Ceradon Systems Crest</title>
+  <desc id="desc">Dark shield with a silver falcon and Ceradon blue strike bands</desc>
   <defs>
-    <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1e57c8" />
-      <stop offset="100%" stop-color="#0d2d73" />
+    <linearGradient id="shieldBase" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#101728" />
+      <stop offset="100%" stop-color="#05070d" />
+    </linearGradient>
+    <linearGradient id="shieldEdge" x1="30%" y1="10%" x2="90%" y2="90%">
+      <stop offset="0%" stop-color="#223044" />
+      <stop offset="100%" stop-color="#121a2c" />
+    </linearGradient>
+    <linearGradient id="innerGlow" x1="28%" y1="18%" x2="84%" y2="86%">
+      <stop offset="0%" stop-color="#1b2539" />
+      <stop offset="100%" stop-color="#060910" />
+    </linearGradient>
+    <linearGradient id="stripeGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b78ff" />
+      <stop offset="100%" stop-color="#56b7ff" />
+    </linearGradient>
+    <linearGradient id="headFill" x1="32%" y1="12%" x2="72%" y2="88%">
+      <stop offset="0%" stop-color="#f6f8fd" />
+      <stop offset="100%" stop-color="#bac3d5" />
+    </linearGradient>
+    <linearGradient id="headShade" x1="24%" y1="0%" x2="90%" y2="90%">
+      <stop offset="0%" stop-color="#c5cddb" />
+      <stop offset="100%" stop-color="#7f8797" />
     </linearGradient>
   </defs>
-  <rect width="256" height="256" rx="32" fill="#0b0d10" />
-  <path fill="url(#shieldGradient)" d="M128 32 64 56v74c0 52 33.4 90.2 64 94 30.6-3.8 64-42 64-94V56L128 32z" />
-  <path fill="#e7eaee" d="M92 104c18 8 26 12 36 12s18-4 36-12l12 18c-20 10-32 14-48 14s-28-4-48-14l12-18z" opacity="0.85" />
-  <path fill="#b8bdc5" d="M128 70c-18 0-36 6-48 12l10 18c14-8 24-12 38-12s24 4 38 12l10-18c-12-6-30-12-48-12z" />
-  <path fill="#e7eaee" d="M128 138c-10 0-20-2-30-6l-10 16c14 8 26 12 40 12s26-4 40-12l-10-16c-10 4-20 6-30 6z" opacity="0.75" />
+  <rect width="512" height="512" rx="64" fill="#03050a" />
+  <path d="M256 32 96 104v164c0 120 82 212 160 240 78-28 160-120 160-240V104L256 32z" fill="url(#shieldBase)" stroke="url(#shieldEdge)" stroke-width="10" stroke-linejoin="round" />
+  <path d="M256 64 128 120v140c0 94 60 176 128 204 68-28 128-110 128-204V120L256 64z" fill="url(#innerGlow)" opacity="0.82" />
+  <g transform="translate(0 -4)">
+    <path d="M360 214c-10-32-32-68-78-90-50-22-122-6-162 46-18 24-26 52-26 80 0 12 2 24 4 34l44 24 18-46c16-38 48-60 88-60 30 0 56 16 66 40l-58 36 88 14 44-34c8-8 10-20-4-32-14-12-24-28-22-34z" fill="url(#headFill)" />
+    <path d="M190 198c18-30 54-48 92-44 34 4 60 22 76 52 4 10 2 20-6 28-32 26-78 40-118 40-42 0-80-12-112-30 0-12 4-30 16-46 16-20 32-32 52-40z" fill="url(#headShade)" opacity="0.45" />
+    <path d="M356 258c-20 8-42 12-64 12-22 0-52-6-80-18l-12 32c42 16 88 20 128 12 26-6 44-16 60-28l-32-10z" fill="#5a6274" opacity="0.35" />
+    <path d="M308 180c-8-10-22-18-36-18-10 0-20 4-30 12 28 2 46 12 58 28l36 18c0-14-12-30-28-40z" fill="#707889" opacity="0.4" />
+    <path d="M352 232c8 10 2 24-10 32-20 12-46 18-74 18-36 0-72-10-96-20 0-12 4-24 10-34 18 12 40 20 62 22 30 2 60-4 84-18 12-8 18-8 24 0z" fill="#eceff6" opacity="0.35" />
+    <path d="M348 268c-28 22-64 34-102 34-42 0-82-12-112-34 2 12 6 22 10 30 32 18 66 28 102 28 38 0 74-12 110-38l-8-20z" fill="#afb7c7" opacity="0.25" />
+    <path d="M360 214c-4-10-12-22-22-32-6 6-18 10-32 10-8 0-16-2-22-4-18-6-36-4-50 4 32 2 60 18 74 40 20 32 12 60-4 78 34-10 60-30 74-52 8-12 8-26 0-44z" fill="#dfe5f1" opacity="0.6" />
+    <path d="M338 208c-4-14-18-24-36-24-14 0-28 6-38 16l-22 22c22 10 46 14 72 12 12-2 22-8 24-16z" fill="#1a2030" opacity="0.45" />
+    <path d="M372 248c-10-10-8-28 6-44 8 10 12 18 14 24 2 10-2 18-10 22l-10-2z" fill="#5c6474" opacity="0.4" />
+    <path d="M330 214c8 4 12 12 10 18-2 6-8 10-16 10-8 0-18-4-28-12 10-12 24-16 34-16z" fill="#151b27" opacity="0.75" />
+    <circle cx="320" cy="214" r="8" fill="#07090f" />
+    <circle cx="322" cy="212" r="3" fill="#f6f8fd" />
+    <path d="M348 234c-10 8-24 14-40 18-18 4-36 4-54 2-22-2-44-10-66-22l-6 16c28 16 58 26 88 28 28 0 54-6 76-18 12-6 20-14 24-22-6-2-14-2-22-2z" fill="#c7cede" opacity="0.35" />
+  </g>
+  <g fill="none" stroke="url(#stripeGradient)" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M132 326c60 48 148 58 228 28" stroke-width="28" opacity="0.85" />
+    <path d="M148 368c54 40 134 48 204 26" stroke-width="24" opacity="0.7" />
+    <path d="M170 408c46 32 110 38 166 22" stroke-width="20" opacity="0.55" />
+  </g>
 </svg>

--- a/assets/vantage-mark.svg
+++ b/assets/vantage-mark.svg
@@ -1,10 +1,33 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
-  <title id="title">Vantage Crest</title>
-  <desc id="desc">Shield with angular radar bands for the Vantage product mark</desc>
-  <rect width="256" height="256" rx="32" fill="#0b0d10" />
-  <path fill="#1e57c8" d="M128 28 60 54v82c0 54 34 99 68 104 34-5 68-50 68-104V54L128 28z" />
-  <path fill="#0d2d73" d="M128 36 76 56v76c0 44 26 82 52 92 26-10 52-48 52-92V56l-52-20z" />
-  <path fill="#e7eaee" d="M76 120c34 18 52 22 52 22s18-4 52-22l16 28c-40 22-56 26-68 26s-28-4-68-26l16-28z" opacity="0.85" />
-  <path fill="none" stroke="#b8bdc5" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" d="M92 96c18 10 36 16 36 16s18-6 36-16" />
-  <path fill="none" stroke="#e7eaee" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" opacity="0.6" d="M100 76c16 8 28 12 28 12s12-4 28-12" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Vantage Scanner Crest</title>
+  <desc id="desc">Angular shield with radiating Ceradon blue bands forming a V</desc>
+  <defs>
+    <linearGradient id="shieldBase" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#111a2c" />
+      <stop offset="100%" stop-color="#05070d" />
+    </linearGradient>
+    <linearGradient id="shieldEdge" x1="20%" y1="0%" x2="80%" y2="100%">
+      <stop offset="0%" stop-color="#203047" />
+      <stop offset="100%" stop-color="#0d1421" />
+    </linearGradient>
+    <linearGradient id="bandGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2b78ff" />
+      <stop offset="100%" stop-color="#56b7ff" />
+    </linearGradient>
+    <radialGradient id="coreGlow" cx="50%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#56b7ff" stop-opacity="0.25" />
+      <stop offset="100%" stop-color="#56b7ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" rx="48" fill="#03050a" />
+  <path d="M256 28 92 96v172c0 118 96 214 164 242 68-28 164-124 164-242V96L256 28z" fill="url(#shieldBase)" stroke="url(#shieldEdge)" stroke-width="12" stroke-linejoin="round" />
+  <path d="M256 68 136 120v140c0 96 72 178 120 200 48-22 120-104 120-200V120L256 68z" fill="#0b1220" opacity="0.8" />
+  <circle cx="256" cy="160" r="152" fill="url(#coreGlow)" />
+  <g fill="none" stroke="url(#bandGradient)" stroke-linecap="round" stroke-width="26">
+    <path d="M156 212c38 56 70 108 100 170 4 8 12 12 20 12s16-4 20-12c30-62 62-114 100-170" opacity="0.85" />
+    <path d="M136 250c40 52 76 108 108 170 4 8 12 12 20 12s16-4 20-12c32-62 68-118 108-170" opacity="0.55" />
+    <path d="M116 288c40 56 80 118 120 184 4 6 12 10 20 10s16-4 20-10c40-66 80-128 120-184" opacity="0.35" />
+  </g>
+  <path d="M256 152c-28 0-52 16-64 40l64 162 64-162c-12-24-36-40-64-40z" fill="#e6ebf5" opacity="0.16" />
+  <path d="M256 184c-16 0-30 10-38 24l38 98 38-98c-8-14-22-24-38-24z" fill="#56b7ff" opacity="0.12" />
 </svg>

--- a/careers.html
+++ b/careers.html
@@ -23,13 +23,14 @@
         theme: {
           extend: {
             colors: {
-              ink: '#0b0d10',
-              'steel-900': '#1b1f24',
-              'steel-700': '#2c3238',
-              'steel-500': '#3c444d',
-              silver: '#b8bdc5',
-              white: '#e7eaee',
-              'ceradon-blue': '#1e57c8'
+              ink: '#04070d',
+              'steel-900': '#0b1220',
+              'steel-700': '#18243a',
+              'steel-500': '#2a3a55',
+              silver: '#c5cbd6',
+              white: '#f4f6fb',
+              'ceradon-blue': '#2b78ff',
+              'ceradon-sky': '#56b7ff'
             },
             fontFamily: {
               sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']

--- a/company.html
+++ b/company.html
@@ -23,13 +23,14 @@
         theme: {
           extend: {
             colors: {
-              ink: '#0b0d10',
-              'steel-900': '#1b1f24',
-              'steel-700': '#2c3238',
-              'steel-500': '#3c444d',
-              silver: '#b8bdc5',
-              white: '#e7eaee',
-              'ceradon-blue': '#1e57c8'
+              ink: '#04070d',
+              'steel-900': '#0b1220',
+              'steel-700': '#18243a',
+              'steel-500': '#2a3a55',
+              silver: '#c5cbd6',
+              white: '#f4f6fb',
+              'ceradon-blue': '#2b78ff',
+              'ceradon-sky': '#56b7ff'
             },
             fontFamily: {
               sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']

--- a/contact.html
+++ b/contact.html
@@ -23,13 +23,14 @@
         theme: {
           extend: {
             colors: {
-              ink: '#0b0d10',
-              'steel-900': '#1b1f24',
-              'steel-700': '#2c3238',
-              'steel-500': '#3c444d',
-              silver: '#b8bdc5',
-              white: '#e7eaee',
-              'ceradon-blue': '#1e57c8'
+              ink: '#04070d',
+              'steel-900': '#0b1220',
+              'steel-700': '#18243a',
+              'steel-500': '#2a3a55',
+              silver: '#c5cbd6',
+              white: '#f4f6fb',
+              'ceradon-blue': '#2b78ff',
+              'ceradon-sky': '#56b7ff'
             },
             fontFamily: {
               sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']

--- a/index.html
+++ b/index.html
@@ -23,13 +23,14 @@
         theme: {
           extend: {
             colors: {
-              ink: '#0b0d10',
-              'steel-900': '#1b1f24',
-              'steel-700': '#2c3238',
-              'steel-500': '#3c444d',
-              silver: '#b8bdc5',
-              white: '#e7eaee',
-              'ceradon-blue': '#1e57c8'
+              ink: '#04070d',
+              'steel-900': '#0b1220',
+              'steel-700': '#18243a',
+              'steel-500': '#2a3a55',
+              silver: '#c5cbd6',
+              white: '#f4f6fb',
+              'ceradon-blue': '#2b78ff',
+              'ceradon-sky': '#56b7ff'
             },
             fontFamily: {
               sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']
@@ -58,8 +59,22 @@
       <!-- mobile panel injected by /src/ui.js -->
     </header>
     <main>
-      <section class="relative overflow-hidden">
-        <div class="absolute inset-0 opacity-40 bg-[radial-gradient(circle_at_top,_rgba(30,87,200,0.18),_transparent_55%)] pointer-events-none"></div>
+      <section class="relative overflow-hidden hero-splash">
+        <div class="absolute inset-0 pointer-events-none">
+          <svg class="absolute -top-32 -right-40 hidden lg:block h-[34rem] w-[34rem] opacity-60" viewBox="0 0 640 640" aria-hidden="true" focusable="false">
+            <defs>
+              <linearGradient id="heroStroke" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stop-color="#2b78ff" stop-opacity="0.75" />
+                <stop offset="100%" stop-color="#56b7ff" stop-opacity="0" />
+              </linearGradient>
+            </defs>
+            <g fill="none" stroke="url(#heroStroke)" stroke-linecap="round" stroke-width="26">
+              <path d="M96 472C256 360 352 232 440 120" opacity="0.35" />
+              <path d="M56 536C240 392 344 236 484 104" opacity="0.55" />
+              <path d="M24 584C224 420 360 232 520 84" opacity="0.8" />
+            </g>
+          </svg>
+        </div>
         <div class="relative mx-auto max-w-7xl px-4 py-20">
           <div class="hero-grid">
             <div class="space-y-8">

--- a/ip.html
+++ b/ip.html
@@ -23,13 +23,14 @@
         theme: {
           extend: {
             colors: {
-              ink: '#0b0d10',
-              'steel-900': '#1b1f24',
-              'steel-700': '#2c3238',
-              'steel-500': '#3c444d',
-              silver: '#b8bdc5',
-              white: '#e7eaee',
-              'ceradon-blue': '#1e57c8'
+              ink: '#04070d',
+              'steel-900': '#0b1220',
+              'steel-700': '#18243a',
+              'steel-500': '#2a3a55',
+              silver: '#c5cbd6',
+              white: '#f4f6fb',
+              'ceradon-blue': '#2b78ff',
+              'ceradon-sky': '#56b7ff'
             },
             fontFamily: {
               sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']

--- a/privacy.html
+++ b/privacy.html
@@ -23,13 +23,14 @@
         theme: {
           extend: {
             colors: {
-              ink: '#0b0d10',
-              'steel-900': '#1b1f24',
-              'steel-700': '#2c3238',
-              'steel-500': '#3c444d',
-              silver: '#b8bdc5',
-              white: '#e7eaee',
-              'ceradon-blue': '#1e57c8'
+              ink: '#04070d',
+              'steel-900': '#0b1220',
+              'steel-700': '#18243a',
+              'steel-500': '#2a3a55',
+              silver: '#c5cbd6',
+              white: '#f4f6fb',
+              'ceradon-blue': '#2b78ff',
+              'ceradon-sky': '#56b7ff'
             },
             fontFamily: {
               sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,11 +1,16 @@
 :root {
-  --ink: #0b0d10;
-  --steel-900: #1b1f24;
-  --steel-700: #2c3238;
-  --steel-500: #3c444d;
-  --silver: #b8bdc5;
-  --white: #e7eaee;
-  --ceradon-blue: #1e57c8;
+  --ink: #04070d;
+  --steel-950: #050911;
+  --steel-900: #0b1220;
+  --steel-800: #111a2c;
+  --steel-700: #18243a;
+  --steel-600: #202f46;
+  --steel-500: #2a3a55;
+  --silver: #c5cbd6;
+  --white: #f4f6fb;
+  --ceradon-blue: #2b78ff;
+  --ceradon-sky: #56b7ff;
+  --ceradon-slate: #80889a;
   color-scheme: dark;
 }
 
@@ -17,15 +22,31 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background-color: var(--ink);
+  min-height: 100%;
+  background: radial-gradient(circle at 12% -10%, rgba(43, 120, 255, 0.2), transparent 55%),
+    radial-gradient(circle at 88% 0%, rgba(86, 183, 255, 0.14), transparent 50%),
+    linear-gradient(180deg, #050910 0%, #04070d 55%, #03050a 100%);
   color: var(--silver);
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
-  min-height: 100%;
 }
 
 body {
   display: flex;
   flex-direction: column;
+  position: relative;
+  min-height: 100vh;
+  background-color: transparent;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(43, 120, 255, 0.1), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(9, 18, 30, 0.6), transparent 60%),
+    linear-gradient(140deg, rgba(43, 120, 255, 0.05) 0%, transparent 50%);
+  pointer-events: none;
+  z-index: -1;
 }
 
 a {
@@ -51,26 +72,34 @@ img {
 .navlink {
   position: relative;
   font-weight: 500;
-  color: var(--silver);
+  letter-spacing: 0.02em;
+  color: rgba(197, 203, 214, 0.85);
   transition: color 0.2s ease, opacity 0.2s ease;
+  padding-bottom: 0.25rem;
 }
 
-.navlink:hover,
-.navlink:focus-visible {
-  color: var(--white);
-}
-
-.navlink[aria-current="page"]::after {
+.navlink::after {
   content: '';
   position: absolute;
   left: 0;
-  bottom: -0.4rem;
+  bottom: 0;
   height: 2px;
   width: 100%;
-  background: linear-gradient(90deg, rgba(30, 87, 200, 0.9), rgba(231, 234, 238, 0.6));
+  background: linear-gradient(90deg, rgba(43, 120, 255, 0), rgba(43, 120, 255, 0.6), rgba(86, 183, 255, 0));
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.2s ease;
 }
 
-.navlink[aria-current="page"] {
+.navlink:hover::after,
+.navlink:focus-visible::after,
+.navlink[aria-current='page']::after {
+  transform: scaleX(1);
+}
+
+.navlink:hover,
+.navlink:focus-visible,
+.navlink[aria-current='page'] {
   color: var(--white);
 }
 
@@ -80,46 +109,64 @@ img {
   justify-content: center;
   font-weight: 600;
   border-radius: 999px;
-  padding: 0.55rem 1.4rem;
-  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+  padding: 0.6rem 1.6rem;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
   border: 1px solid transparent;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
 }
 
 .btn-primary {
-  background: var(--ceradon-blue);
+  background: linear-gradient(135deg, rgba(43, 120, 255, 0.95) 0%, rgba(86, 183, 255, 0.85) 100%);
   color: var(--white);
-  border-color: rgba(30, 87, 200, 0.6);
-  box-shadow: 0 8px 24px rgba(30, 87, 200, 0.25);
+  border-color: rgba(86, 183, 255, 0.4);
+  box-shadow: 0 18px 32px rgba(43, 120, 255, 0.35);
 }
 
 .btn-primary:hover,
 .btn-primary:focus-visible {
-  background: #2764df;
+  background: linear-gradient(135deg, rgba(43, 120, 255, 1) 0%, rgba(123, 206, 255, 0.95) 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 22px 44px rgba(43, 120, 255, 0.45);
 }
 
 .btn-secondary {
-  background: transparent;
-  color: var(--silver);
-  border-color: var(--steel-500);
+  background: rgba(17, 26, 44, 0.65);
+  color: rgba(197, 203, 214, 0.9);
+  border-color: rgba(42, 58, 85, 0.8);
 }
 
 .btn-secondary:hover,
 .btn-secondary:focus-visible {
   color: var(--white);
-  border-color: var(--ceradon-blue);
+  border-color: rgba(86, 183, 255, 0.6);
+  background: rgba(17, 26, 44, 0.85);
 }
 
 .section-heading {
   color: var(--white);
   font-weight: 700;
+  letter-spacing: 0.02em;
 }
 
 .card-glass {
-  background: rgba(27, 31, 36, 0.75);
-  border: 1px solid rgba(60, 68, 77, 0.7);
-  border-radius: 1rem;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(12px);
+  position: relative;
+  background: linear-gradient(160deg, rgba(17, 26, 44, 0.9) 0%, rgba(24, 36, 58, 0.78) 100%);
+  border: 1px solid rgba(86, 183, 255, 0.12);
+  border-radius: 1.1rem;
+  box-shadow: 0 24px 50px rgba(3, 5, 10, 0.45);
+  backdrop-filter: blur(14px);
+  overflow: hidden;
+}
+
+.card-glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(86, 183, 255, 0.18), transparent 55%);
+  opacity: 0.7;
+  pointer-events: none;
 }
 
 .table-dark {
@@ -129,22 +176,27 @@ img {
 
 .table-dark th,
 .table-dark td {
-  border: 1px solid rgba(60, 68, 77, 0.7);
+  border: 1px solid rgba(42, 58, 85, 0.65);
   padding: 1rem;
   text-align: left;
+  background: rgba(17, 26, 44, 0.75);
 }
 
 .table-dark th {
-  background: rgba(27, 31, 36, 0.85);
   color: var(--white);
+  background: linear-gradient(135deg, rgba(17, 26, 44, 0.95), rgba(24, 36, 58, 0.8));
 }
 
-.table-dark tbody tr:nth-child(even) {
-  background: rgba(27, 31, 36, 0.65);
+.table-dark tbody tr:nth-child(even) td {
+  background: rgba(17, 26, 44, 0.6);
 }
 
-.table-dark tbody tr:hover {
-  background: rgba(60, 68, 77, 0.4);
+.table-dark tbody tr:hover td {
+  background: rgba(42, 58, 85, 0.45);
+}
+
+.timeline {
+  position: relative;
 }
 
 .timeline::before {
@@ -154,7 +206,7 @@ img {
   top: 0;
   bottom: 0;
   width: 2px;
-  background: linear-gradient(180deg, rgba(30, 87, 200, 0.1), rgba(30, 87, 200, 0.6));
+  background: linear-gradient(180deg, rgba(43, 120, 255, 0), rgba(43, 120, 255, 0.65));
 }
 
 .timeline-item {
@@ -172,20 +224,20 @@ img {
   height: 14px;
   border-radius: 50%;
   background: var(--ceradon-blue);
-  box-shadow: 0 0 0 4px rgba(30, 87, 200, 0.15);
+  box-shadow: 0 0 0 4px rgba(43, 120, 255, 0.18);
 }
 
 .tag {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  font-size: 0.75rem;
-  letter-spacing: 0.05em;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  padding: 0.25rem 0.75rem;
+  padding: 0.35rem 0.85rem;
   border-radius: 999px;
-  border: 1px solid rgba(30, 87, 200, 0.4);
-  background: rgba(30, 87, 200, 0.1);
+  border: 1px solid rgba(86, 183, 255, 0.35);
+  background: linear-gradient(120deg, rgba(43, 120, 255, 0.16), rgba(86, 183, 255, 0.08));
 }
 
 .focused-outline:focus-visible,
@@ -193,7 +245,7 @@ button:focus-visible,
 input:focus-visible,
 textarea:focus-visible,
 select:focus-visible {
-  outline: 2px solid var(--ceradon-blue);
+  outline: 2px solid rgba(86, 183, 255, 0.85);
   outline-offset: 2px;
 }
 
@@ -204,46 +256,101 @@ form label {
 }
 
 input,
-textarea {
+textarea,
+select {
   width: 100%;
-  background: rgba(27, 31, 36, 0.9);
-  border: 1px solid rgba(60, 68, 77, 0.9);
+  background: rgba(11, 18, 30, 0.85);
+  border: 1px solid rgba(42, 58, 85, 0.8);
   border-radius: 0.75rem;
-  padding: 0.75rem 1rem;
+  padding: 0.85rem 1rem;
   color: var(--silver);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: rgba(86, 183, 255, 0.7);
+  box-shadow: 0 0 0 3px rgba(43, 120, 255, 0.15);
 }
 
 input::placeholder,
 textarea::placeholder {
-  color: rgba(184, 189, 197, 0.7);
+  color: rgba(128, 136, 154, 0.8);
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.35rem 0.65rem;
-  border-radius: 0.65rem;
-  border: 1px solid rgba(184, 189, 197, 0.2);
-  background: rgba(27, 31, 36, 0.85);
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.7rem;
+  border: 1px solid rgba(197, 203, 214, 0.2);
+  background: rgba(11, 18, 30, 0.8);
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  color: rgba(197, 203, 214, 0.85);
 }
 
 .hero-grid {
   display: grid;
-  gap: 2rem;
+  gap: 2.5rem;
+  align-items: center;
 }
 
 @media (min-width: 768px) {
   .hero-grid {
-    grid-template-columns: 1.1fr 1fr;
-    align-items: center;
+    grid-template-columns: 1.05fr 1fr;
   }
 }
 
+.hero-splash {
+  position: relative;
+  isolation: isolate;
+}
+
+.hero-splash::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(43, 120, 255, 0.32), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(86, 183, 255, 0.22), transparent 55%),
+    linear-gradient(160deg, rgba(11, 18, 30, 0.9) 0%, rgba(4, 7, 13, 0.6) 100%);
+  opacity: 0.85;
+  z-index: -2;
+}
+
+.hero-splash::after {
+  content: '';
+  position: absolute;
+  top: 20%;
+  right: -10%;
+  width: 45rem;
+  height: 45rem;
+  background: radial-gradient(circle, rgba(43, 120, 255, 0.18) 0%, transparent 70%);
+  filter: blur(12rem);
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: -1;
+}
+
+footer {
+  position: relative;
+  overflow: hidden;
+}
+
+footer::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(17, 26, 44, 0.95) 0%, rgba(4, 7, 13, 0.8) 100%);
+  opacity: 0.9;
+  z-index: -1;
+}
+
 footer a {
-  color: rgba(184, 189, 197, 0.8);
+  color: rgba(197, 203, 214, 0.8);
 }
 
 footer a:hover,
@@ -276,8 +383,9 @@ footer a:focus-visible {
 .gallery-card {
   overflow: hidden;
   border-radius: 1rem;
-  border: 1px solid rgba(60, 68, 77, 0.6);
-  background: rgba(27, 31, 36, 0.7);
+  border: 1px solid rgba(42, 58, 85, 0.55);
+  background: rgba(11, 18, 30, 0.75);
+  box-shadow: 0 18px 36px rgba(3, 5, 10, 0.35);
 }
 
 .gallery-card img {
@@ -291,18 +399,19 @@ footer a:focus-visible {
 }
 
 .shadow-border {
-  border: 1px solid rgba(60, 68, 77, 0.6);
-  box-shadow: inset 0 0 0 1px rgba(231, 234, 238, 0.05);
+  border: 1px solid rgba(42, 58, 85, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(244, 246, 251, 0.05), 0 12px 28px rgba(3, 5, 10, 0.25);
+  background: linear-gradient(145deg, rgba(11, 18, 30, 0.9), rgba(17, 26, 44, 0.65));
 }
 
 .gradient-divider {
   height: 1px;
-  background: linear-gradient(90deg, rgba(231, 234, 238, 0), rgba(231, 234, 238, 0.45), rgba(231, 234, 238, 0));
+  background: linear-gradient(90deg, rgba(244, 246, 251, 0), rgba(244, 246, 251, 0.35), rgba(244, 246, 251, 0));
   margin: 3rem 0;
 }
 
 .text-subtle {
-  color: rgba(184, 189, 197, 0.85);
+  color: rgba(197, 203, 214, 0.85);
 }
 
 .bento-grid {
@@ -326,4 +435,3 @@ footer a:focus-visible {
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
-

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,13 +4,14 @@ export default {
   theme: {
     extend: {
       colors: {
-        ink: '#0b0d10',
-        'steel-900': '#1b1f24',
-        'steel-700': '#2c3238',
-        'steel-500': '#3c444d',
-        silver: '#b8bdc5',
-        white: '#e7eaee',
-        'ceradon-blue': '#1e57c8'
+        ink: '#04070d',
+        'steel-900': '#0b1220',
+        'steel-700': '#18243a',
+        'steel-500': '#2a3a55',
+        silver: '#c5cbd6',
+        white: '#f4f6fb',
+        'ceradon-blue': '#2b78ff',
+        'ceradon-sky': '#56b7ff'
       },
       fontFamily: {
         sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']

--- a/technology.html
+++ b/technology.html
@@ -23,13 +23,14 @@
         theme: {
           extend: {
             colors: {
-              ink: '#0b0d10',
-              'steel-900': '#1b1f24',
-              'steel-700': '#2c3238',
-              'steel-500': '#3c444d',
-              silver: '#b8bdc5',
-              white: '#e7eaee',
-              'ceradon-blue': '#1e57c8'
+              ink: '#04070d',
+              'steel-900': '#0b1220',
+              'steel-700': '#18243a',
+              'steel-500': '#2a3a55',
+              silver: '#c5cbd6',
+              white: '#f4f6fb',
+              'ceradon-blue': '#2b78ff',
+              'ceradon-sky': '#56b7ff'
             },
             fontFamily: {
               sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']

--- a/vantage.html
+++ b/vantage.html
@@ -23,13 +23,14 @@
         theme: {
           extend: {
             colors: {
-              ink: '#0b0d10',
-              'steel-900': '#1b1f24',
-              'steel-700': '#2c3238',
-              'steel-500': '#3c444d',
-              silver: '#b8bdc5',
-              white: '#e7eaee',
-              'ceradon-blue': '#1e57c8'
+              ink: '#04070d',
+              'steel-900': '#0b1220',
+              'steel-700': '#18243a',
+              'steel-500': '#2a3a55',
+              silver: '#c5cbd6',
+              white: '#f4f6fb',
+              'ceradon-blue': '#2b78ff',
+              'ceradon-sky': '#56b7ff'
             },
             fontFamily: {
               sans: ['Inter', 'Segoe UI', 'system-ui', 'sans-serif']
@@ -58,8 +59,23 @@
       <!-- mobile panel injected by /src/ui.js -->
     </header>
     <main>
-      <section class="border-b border-[color:var(--steel-700)] bg-[color:var(--steel-900)/50]">
-        <div class="mx-auto max-w-7xl px-4 py-16">
+      <section class="relative overflow-hidden hero-splash border-b border-[color:var(--steel-700)]">
+        <div class="absolute inset-0 pointer-events-none">
+          <svg class="absolute -bottom-20 -left-28 hidden lg:block h-[26rem] w-[26rem] opacity-40" viewBox="0 0 480 480" aria-hidden="true" focusable="false">
+            <defs>
+              <linearGradient id="vantageStroke" x1="0%" y1="100%" x2="100%" y2="0%">
+                <stop offset="0%" stop-color="#2b78ff" stop-opacity="0.1" />
+                <stop offset="100%" stop-color="#56b7ff" stop-opacity="0.6" />
+              </linearGradient>
+            </defs>
+            <g fill="none" stroke="url(#vantageStroke)" stroke-linecap="round" stroke-width="20">
+              <path d="M40 320C160 252 236 172 320 88" />
+              <path d="M20 356C148 268 236 168 356 60" opacity="0.6" />
+              <path d="M0 392C132 292 236 172 388 36" opacity="0.4" />
+            </g>
+          </svg>
+        </div>
+        <div class="relative mx-auto max-w-7xl px-4 py-16">
           <div class="grid gap-12 lg:grid-cols-[3fr_2fr] lg:items-center">
             <div class="space-y-6">
               <span class="tag">Vantage Platform</span>


### PR DESCRIPTION
## Summary
- replace the wordmark, favicon, and Vantage crest with a high-contrast Ceradon shield that matches the LLC branding assets
- retune the global dark theme, button treatments, and hero backgrounds for a brighter Ceradon blue aesthetic across the site
- align the Tailwind color extensions in every static page so utility classes use the refreshed palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca559a372c8328896a069aa0fc5078