### PR TITLE
Switch site imagery to provided placeholders

### DIFF
--- a/careers.html
+++ b/careers.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Help build Vantage—passive Wi-Fi CSI sensing that delivers through-wall pose intelligence." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ceradonsystems.com/careers.html" />
-    <meta property="og:image" content="/assets/logo-mark.svg" />
+    <meta property="og:image" content="/assets/Square_Logo.PNG" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Careers | Ceradon Systems" />
     <meta name="twitter:description" content="Help build Vantage—passive Wi-Fi CSI sensing that delivers through-wall pose intelligence." />
-    <meta name="twitter:image" content="/assets/logo-mark.svg" />
+    <meta name="twitter:image" content="/assets/Square_Logo.PNG" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/styles/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,8 +43,8 @@
   <body class="bg-[color:var(--ink)] text-[color:var(--silver)]">
     <header class="backdrop-blur bg-[color:var(--steel-900)/70] sticky top-0 z-50 border-b border-[color:var(--steel-700)]">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
-        <a href="/"><img class="hidden sm:block h-10" src="/assets/logo-horizontal.svg" alt="Ceradon Systems logo"/>
-                   <img class="sm:hidden h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark"/></a>
+        <a href="/"><img class="hidden sm:block h-10" src="/assets/Horizontal_Logo.PNG" alt="Ceradon Systems logo"/>
+                   <img class="sm:hidden h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark"/></a>
         <nav class="hidden md:flex gap-6">
           <!-- add active link state using aria-current="page" -->
           <a href="/" class="navlink">Home</a>
@@ -114,7 +114,7 @@
       <div class="mx-auto max-w-7xl px-4 py-12 space-y-10">
         <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div class="flex items-center gap-4">
-            <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-12 w-12" />
+            <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-12 w-12" />
             <div>
               <p class="font-semibold text-[color:var(--white)]">Ceradon Systems</p>
               <p class="text-sm text-subtle">Passive RF sensing for decisive teams.</p>

--- a/company.html
+++ b/company.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Meet the team building passive RF sensing and pose intelligence for tactical operations." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ceradonsystems.com/company.html" />
-    <meta property="og:image" content="/assets/logo-mark.svg" />
+    <meta property="og:image" content="/assets/Square_Logo.PNG" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Company | Ceradon Systems" />
     <meta name="twitter:description" content="Meet the team building passive RF sensing and pose intelligence for tactical operations." />
-    <meta name="twitter:image" content="/assets/logo-mark.svg" />
+    <meta name="twitter:image" content="/assets/Square_Logo.PNG" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/styles/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,8 +43,8 @@
   <body class="bg-[color:var(--ink)] text-[color:var(--silver)]">
     <header class="backdrop-blur bg-[color:var(--steel-900)/70] sticky top-0 z-50 border-b border-[color:var(--steel-700)]">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
-        <a href="/"><img class="hidden sm:block h-10" src="/assets/logo-horizontal.svg" alt="Ceradon Systems logo"/>
-                   <img class="sm:hidden h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark"/></a>
+        <a href="/"><img class="hidden sm:block h-10" src="/assets/Horizontal_Logo.PNG" alt="Ceradon Systems logo"/>
+                   <img class="sm:hidden h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark"/></a>
         <nav class="hidden md:flex gap-6">
           <!-- add active link state using aria-current="page" -->
           <a href="/" class="navlink">Home</a>
@@ -143,7 +143,7 @@
       <div class="mx-auto max-w-7xl px-4 py-12 space-y-10">
         <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div class="flex items-center gap-4">
-            <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-12 w-12" />
+            <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-12 w-12" />
             <div>
               <p class="font-semibold text-[color:var(--white)]">Ceradon Systems</p>
               <p class="text-sm text-subtle">Passive RF sensing for decisive teams.</p>

--- a/contact.html
+++ b/contact.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Reach out to Ceradon Systems for Vantage demos, partnerships, or secure briefings." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ceradonsystems.com/contact.html" />
-    <meta property="og:image" content="/assets/logo-mark.svg" />
+    <meta property="og:image" content="/assets/Square_Logo.PNG" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Contact | Ceradon Systems" />
     <meta name="twitter:description" content="Reach out to Ceradon Systems for Vantage demos, partnerships, or secure briefings." />
-    <meta name="twitter:image" content="/assets/logo-mark.svg" />
+    <meta name="twitter:image" content="/assets/Square_Logo.PNG" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/styles/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,8 +43,8 @@
   <body class="bg-[color:var(--ink)] text-[color:var(--silver)]">
     <header class="backdrop-blur bg-[color:var(--steel-900)/70] sticky top-0 z-50 border-b border-[color:var(--steel-700)]">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
-        <a href="/"><img class="hidden sm:block h-10" src="/assets/logo-horizontal.svg" alt="Ceradon Systems logo"/>
-                   <img class="sm:hidden h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark"/></a>
+        <a href="/"><img class="hidden sm:block h-10" src="/assets/Horizontal_Logo.PNG" alt="Ceradon Systems logo"/>
+                   <img class="sm:hidden h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark"/></a>
         <nav class="hidden md:flex gap-6">
           <!-- add active link state using aria-current="page" -->
           <a href="/" class="navlink">Home</a>
@@ -63,7 +63,7 @@
         <div class="grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
           <div class="card-glass p-8 space-y-6">
             <div class="flex items-center gap-4">
-              <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-16 w-16" />
+              <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-16 w-16" />
               <div>
                 <h1 class="text-3xl font-bold text-[color:var(--white)]">Contact Ceradon Systems</h1>
                 <p class="text-sm text-subtle">Trusted RF sensing for the edge.</p>
@@ -114,7 +114,7 @@
       <div class="mx-auto max-w-7xl px-4 py-12 space-y-10">
         <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div class="flex items-center gap-4">
-            <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-12 w-12" />
+            <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-12 w-12" />
             <div>
               <p class="font-semibold text-[color:var(--white)]">Ceradon Systems</p>
               <p class="text-sm text-subtle">Passive RF sensing for decisive teams.</p>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Passive, through-wall human sensing built for mission-critical operations." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ceradonsystems.com/" />
-    <meta property="og:image" content="/assets/logo-mark.svg" />
+    <meta property="og:image" content="/assets/Square_Logo.PNG" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Ceradon Systems | Trusted RF Sensing for the Edge" />
     <meta name="twitter:description" content="Passive, through-wall human sensing built for mission-critical operations." />
-    <meta name="twitter:image" content="/assets/logo-mark.svg" />
+    <meta name="twitter:image" content="/assets/Square_Logo.PNG" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/styles/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,8 +43,8 @@
   <body class="bg-[color:var(--ink)] text-[color:var(--silver)]">
     <header class="backdrop-blur bg-[color:var(--steel-900)/70] sticky top-0 z-50 border-b border-[color:var(--steel-700)]">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
-        <a href="/"><img class="hidden sm:block h-10" src="/assets/logo-horizontal.svg" alt="Ceradon Systems logo"/>
-                   <img class="sm:hidden h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark"/></a>
+        <a href="/"><img class="hidden sm:block h-10" src="/assets/Horizontal_Logo.PNG" alt="Ceradon Systems logo"/>
+                   <img class="sm:hidden h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark"/></a>
         <nav class="hidden md:flex gap-6">
           <!-- add active link state using aria-current="page" -->
           <a href="/" class="navlink">Home</a>
@@ -82,7 +82,7 @@
                 <span class="w-2 h-2 rounded-full bg-[color:var(--ceradon-blue)]"></span>
                 Passive RF Situational Awareness
               </div>
-              <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-24 w-24 sm:h-32 sm:w-32" />
+              <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-24 w-24 sm:h-32 sm:w-32" />
               <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-[color:var(--white)] leading-tight">
                 Vantage Scanner: Through-wall pose intelligence.
               </h1>
@@ -186,7 +186,7 @@
 
           <div class="relative overflow-hidden rounded-2xl border border-[color:var(--steel-700)] bg-[color:var(--steel-900)/70]">
             <a href="/vantage.html" class="block p-8 md:p-12">
-              <div class="absolute inset-0 opacity-10 bg-cover bg-right" style="background-image: url('/assets/vantage-mark.svg');"></div>
+              <div class="absolute inset-0 opacity-10 bg-cover bg-right" style="background-image: url('/assets/VantageLong.PNG');"></div>
               <div class="relative space-y-4 max-w-3xl">
                 <span class="tag">Product Spotlight</span>
                 <h2 class="text-3xl md:text-4xl font-semibold text-[color:var(--white)]">Vantage transforms ambient Wi-Fi into tactical intelligence.</h2>
@@ -304,7 +304,7 @@
       <div class="mx-auto max-w-7xl px-4 py-12 space-y-10">
         <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div class="flex items-center gap-4">
-            <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-12 w-12" />
+            <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-12 w-12" />
             <div>
               <p class="font-semibold text-[color:var(--white)]">Ceradon Systems</p>
               <p class="text-sm text-subtle">Passive RF sensing for decisive teams.</p>

--- a/ip.html
+++ b/ip.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Discover how Ceradon Systems protects passive sensing innovation and maintains compliance." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ceradonsystems.com/ip.html" />
-    <meta property="og:image" content="/assets/logo-mark.svg" />
+    <meta property="og:image" content="/assets/Square_Logo.PNG" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="IP & Compliance | Ceradon Systems" />
     <meta name="twitter:description" content="Discover how Ceradon Systems protects passive sensing innovation and maintains compliance." />
-    <meta name="twitter:image" content="/assets/logo-mark.svg" />
+    <meta name="twitter:image" content="/assets/Square_Logo.PNG" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/styles/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,8 +43,8 @@
   <body class="bg-[color:var(--ink)] text-[color:var(--silver)]">
     <header class="backdrop-blur bg-[color:var(--steel-900)/70] sticky top-0 z-50 border-b border-[color:var(--steel-700)]">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
-        <a href="/"><img class="hidden sm:block h-10" src="/assets/logo-horizontal.svg" alt="Ceradon Systems logo"/>
-                   <img class="sm:hidden h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark"/></a>
+        <a href="/"><img class="hidden sm:block h-10" src="/assets/Horizontal_Logo.PNG" alt="Ceradon Systems logo"/>
+                   <img class="sm:hidden h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark"/></a>
         <nav class="hidden md:flex gap-6">
           <!-- add active link state using aria-current="page" -->
           <a href="/" class="navlink">Home</a>
@@ -106,7 +106,7 @@
       <div class="mx-auto max-w-7xl px-4 py-12 space-y-10">
         <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div class="flex items-center gap-4">
-            <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-12 w-12" />
+            <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-12 w-12" />
             <div>
               <p class="font-semibold text-[color:var(--white)]">Ceradon Systems</p>
               <p class="text-sm text-subtle">Passive RF sensing for decisive teams.</p>

--- a/privacy.html
+++ b/privacy.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Ceradon Systems privacy policy for this static marketing site." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ceradonsystems.com/privacy.html" />
-    <meta property="og:image" content="/assets/logo-mark.svg" />
+    <meta property="og:image" content="/assets/Square_Logo.PNG" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Privacy Policy | Ceradon Systems" />
     <meta name="twitter:description" content="Ceradon Systems privacy policy for this static marketing site." />
-    <meta name="twitter:image" content="/assets/logo-mark.svg" />
+    <meta name="twitter:image" content="/assets/Square_Logo.PNG" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/styles/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,8 +43,8 @@
   <body class="bg-[color:var(--ink)] text-[color:var(--silver)]">
     <header class="backdrop-blur bg-[color:var(--steel-900)/70] sticky top-0 z-50 border-b border-[color:var(--steel-700)]">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
-        <a href="/"><img class="hidden sm:block h-10" src="/assets/logo-horizontal.svg" alt="Ceradon Systems logo"/>
-                   <img class="sm:hidden h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark"/></a>
+        <a href="/"><img class="hidden sm:block h-10" src="/assets/Horizontal_Logo.PNG" alt="Ceradon Systems logo"/>
+                   <img class="sm:hidden h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark"/></a>
         <nav class="hidden md:flex gap-6">
           <!-- add active link state using aria-current="page" -->
           <a href="/" class="navlink">Home</a>
@@ -77,7 +77,7 @@
       <div class="mx-auto max-w-7xl px-4 py-12 space-y-10">
         <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div class="flex items-center gap-4">
-            <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-12 w-12" />
+            <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-12 w-12" />
             <div>
               <p class="font-semibold text-[color:var(--white)]">Ceradon Systems</p>
               <p class="text-sm text-subtle">Passive RF sensing for decisive teams.</p>

--- a/src/ui.js
+++ b/src/ui.js
@@ -80,7 +80,7 @@ function buildMobileNav(header) {
   panel.style.zIndex = '70';
   panel.innerHTML = `
     <div class="px-6 py-5 flex items-center justify-between border-b border-[color:var(--steel-700)]">
-      <img class="h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark" />
+      <img class="h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" />
       <button class="text-2xl" aria-label="Close menu" data-close-menu>&times;</button>
     </div>
     <div class="flex-1 overflow-y-auto px-6 py-6">

--- a/technology.html
+++ b/technology.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Explore passive Wi-Fi CSI sensing, roadmap milestones, and how Vantage stays secure and ethical in contested environments." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ceradonsystems.com/technology.html" />
-    <meta property="og:image" content="/assets/logo-mark.svg" />
+    <meta property="og:image" content="/assets/Square_Logo.PNG" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Technology | Ceradon Systems" />
     <meta name="twitter:description" content="Explore passive Wi-Fi CSI sensing, roadmap milestones, and how Vantage stays secure and ethical in contested environments." />
-    <meta name="twitter:image" content="/assets/logo-mark.svg" />
+    <meta name="twitter:image" content="/assets/Square_Logo.PNG" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/styles/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,8 +43,8 @@
   <body class="bg-[color:var(--ink)] text-[color:var(--silver)]">
     <header class="backdrop-blur bg-[color:var(--steel-900)/70] sticky top-0 z-50 border-b border-[color:var(--steel-700)]">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
-        <a href="/"><img class="hidden sm:block h-10" src="/assets/logo-horizontal.svg" alt="Ceradon Systems logo"/>
-                   <img class="sm:hidden h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark"/></a>
+        <a href="/"><img class="hidden sm:block h-10" src="/assets/Horizontal_Logo.PNG" alt="Ceradon Systems logo"/>
+                   <img class="sm:hidden h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark"/></a>
         <nav class="hidden md:flex gap-6">
           <!-- add active link state using aria-current="page" -->
           <a href="/" class="navlink">Home</a>
@@ -172,7 +172,7 @@
       <div class="mx-auto max-w-7xl px-4 py-12 space-y-10">
         <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div class="flex items-center gap-4">
-            <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-12 w-12" />
+            <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-12 w-12" />
             <div>
               <p class="font-semibold text-[color:var(--white)]">Ceradon Systems</p>
               <p class="text-sm text-subtle">Passive RF sensing for decisive teams.</p>

--- a/vantage.html
+++ b/vantage.html
@@ -9,11 +9,11 @@
     <meta property="og:description" content="Detect presence, pose, motion, and behavior through walls with zero-emission RF sensing." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ceradonsystems.com/vantage.html" />
-    <meta property="og:image" content="/assets/vantage-mark.svg" />
+    <meta property="og:image" content="/assets/VantageLong.PNG" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Vantage | Passive Through-Wall Awareness" />
     <meta name="twitter:description" content="Detect presence, pose, motion, and behavior through walls with zero-emission RF sensing." />
-    <meta name="twitter:image" content="/assets/vantage-mark.svg" />
+    <meta name="twitter:image" content="/assets/VantageLong.PNG" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <link rel="stylesheet" href="/styles/styles.css" />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -43,8 +43,8 @@
   <body class="bg-[color:var(--ink)] text-[color:var(--silver)]">
     <header class="backdrop-blur bg-[color:var(--steel-900)/70] sticky top-0 z-50 border-b border-[color:var(--steel-700)]">
       <div class="mx-auto max-w-7xl px-4 py-3 flex items-center justify-between">
-        <a href="/"><img class="hidden sm:block h-10" src="/assets/logo-horizontal.svg" alt="Ceradon Systems logo"/>
-                   <img class="sm:hidden h-10" src="/assets/logo-mark.svg" alt="Ceradon Systems mark"/></a>
+        <a href="/"><img class="hidden sm:block h-10" src="/assets/Horizontal_Logo.PNG" alt="Ceradon Systems logo"/>
+                   <img class="sm:hidden h-10" src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark"/></a>
         <nav class="hidden md:flex gap-6">
           <!-- add active link state using aria-current="page" -->
           <a href="/" class="navlink">Home</a>
@@ -88,7 +88,7 @@
               </div>
             </div>
             <div class="card-glass p-8 space-y-4">
-              <img src="/assets/vantage-mark.svg" alt="Vantage shield" class="h-20 w-20" />
+              <img src="/assets/VantageLong.PNG" alt="Vantage shield" class="h-20 w-20" />
               <p class="text-subtle">Every capability centers on resilient pose estimation so operators understand posture and intent before breaching.</p>
               <a href="/contact.html" class="btn btn-primary text-sm uppercase tracking-wide">Request a Demo</a>
             </div>
@@ -222,7 +222,7 @@
       <div class="mx-auto max-w-7xl px-4 py-12 space-y-10">
         <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
           <div class="flex items-center gap-4">
-            <img src="/assets/logo-mark.svg" alt="Ceradon Systems mark" class="h-12 w-12" />
+            <img src="/assets/Square_Logo.PNG" alt="Ceradon Systems mark" class="h-12 w-12" />
             <div>
               <p class="font-semibold text-[color:var(--white)]">Ceradon Systems</p>
               <p class="text-sm text-subtle">Passive RF sensing for decisive teams.</p>


### PR DESCRIPTION
## Summary
- update navigation, hero, and footer imagery to use the provided Horizontal_Logo.PNG and Square_Logo.PNG assets
- refresh social meta tags across the site to point at the new Ceradon placeholder artwork
- swap Vantage hero artwork and index callout backgrounds over to the VantageLong placeholder

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc86b2297483289b47c0632cc210b6