### PR TITLE
Add site-wide mission visual stories

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import './input.css';
 import './scroll-animations.js';
 import './immersive-ui.js';
+import './visual-stories.js';
 import { initUI, refreshActiveStates } from './ui.js';
 
 function ready(fn) {

--- a/src/visual-stories.js
+++ b/src/visual-stories.js
@@ -1,0 +1,136 @@
+const VISUAL_STORIES = {
+  '/vantage.html': {
+    eyebrow: 'Mission visualization',
+    title: 'Passive awareness, from signal to decision',
+    copy: 'A clearer look at the environments, sensing model, and operator context behind VANTAGE.',
+    items: [
+      ['./assets/hero-vantage.webp', 'VANTAGE passive WiFi sensing in a built environment', 'Built environment'],
+      ['./assets/section-vantage-preview.webp', 'Passive WiFi signal visualization across a structure', 'Signal picture'],
+      ['./assets/hero-index.webp', 'Operator-focused through-wall awareness visualization', 'Operator context']
+    ]
+  },
+  '/raptor.html': {
+    eyebrow: 'Platform view',
+    title: 'Edge vision across every operating layer',
+    copy: 'From sensor placement to detection and TAK integration, RAPTOR stays close to the mission.',
+    items: [
+      ['./assets/section-raptor-platforms.webp', 'RAPTOR edge AI across supported platforms', 'Multi-platform'],
+      ['./assets/section-raptor-detection.webp', 'RAPTOR real-time object detection interface', 'On-device detection'],
+      ['./assets/section-raptor-tak.webp', 'RAPTOR detections integrated into TAK', 'TAK integration']
+    ]
+  },
+  '/aegis.html': {
+    eyebrow: 'Sensor fusion',
+    title: 'Three sensing modes. One operational picture.',
+    copy: 'AEGIS combines complementary views so teams can detect, classify, and respond with confidence.',
+    items: [
+      ['./assets/section-aegis-sensors.webp', 'AEGIS fused counter-UAS sensor array', 'Sensor layer'],
+      ['./assets/section-aegis-detection.webp', 'AEGIS drone detection and tracking visualization', 'Detection layer'],
+      ['./assets/hero-aegis.webp', 'Counter-UAS system operating in the field', 'Mission layer']
+    ]
+  },
+  '/scout.html': {
+    eyebrow: 'Workflow',
+    title: 'From opportunity noise to a focused pursuit list',
+    copy: 'SCOUT turns a sprawling federal marketplace into a daily, prioritized operating picture.',
+    items: [
+      ['./assets/hero-scout.webp', 'SCOUT federal opportunity intelligence dashboard', 'Opportunity feed'],
+      ['./assets/section-scout-workflow.webp', 'SCOUT contract discovery and scoring workflow', 'Automated workflow'],
+      ['./assets/section-scout-preview.webp', 'Ranked federal contract opportunities in SCOUT', 'Priority view']
+    ]
+  },
+  '/architect.html': {
+    eyebrow: 'System planning',
+    title: 'Make component decisions visible',
+    copy: 'Architect connects mission needs, compatible COTS hardware, and build-ready system structure.',
+    items: [
+      ['./assets/hero-architect.webp', 'COTS unmanned system architecture workspace', 'Mission architecture'],
+      ['./assets/cots-architect-logo.png', 'COTS Architect planning toolkit identity', 'Planning toolkit'],
+      ['./assets/section-tech-edge.webp', 'Rugged edge-compute hardware for autonomous systems', 'Edge hardware']
+    ]
+  },
+  '/technology.html': {
+    eyebrow: 'Technology stack',
+    title: 'Built from edge hardware to operational software',
+    copy: 'The same engineering language connects sensing, inference, networking, and the operator view.',
+    items: [
+      ['./assets/section-tech-edge.webp', 'Rugged edge AI compute platform', 'Edge compute'],
+      ['./assets/section-raptor-detection.webp', 'Real-time edge AI detection overlay', 'Inference'],
+      ['./assets/section-raptor-tak.webp', 'Tactical awareness integration', 'Operator picture']
+    ]
+  },
+  '/company.html': {
+    eyebrow: 'Inside Ceradon',
+    title: 'Small team. Applied engineering. Real hardware.',
+    copy: 'Ceradon is built around rapid prototypes, field constraints, and systems that operators can actually carry.',
+    items: [
+      ['./assets/lab-soldering.jpg', 'Ceradon prototype electronics being assembled in the lab', 'Prototype lab'],
+      ['./assets/hero-company.webp', 'Ceradon Systems engineering and mission focus', 'Mission focus'],
+      ['./assets/section-tech-edge.webp', 'Field-ready edge hardware developed by Ceradon', 'Field hardware']
+    ]
+  }
+};
+
+function normalisePath(pathname) {
+  if (pathname === '/' || pathname.endsWith('/index.html')) return '/';
+  return pathname;
+}
+
+function buildVisualStory(config) {
+  const section = document.createElement('section');
+  section.className = 'visual-story border-t border-white/[0.06]';
+  section.setAttribute('aria-labelledby', 'visual-story-heading');
+  section.innerHTML = `
+    <div class="visual-story__inner">
+      <div class="visual-story__intro" data-animate>
+        <p class="tag">${config.eyebrow}</p>
+        <h2 id="visual-story-heading" class="section-heading">${config.title}</h2>
+        <p>${config.copy}</p>
+      </div>
+      <div class="visual-story__grid" data-animate-stagger>
+        ${config.items.map(([src, alt, label], index) => `
+          <figure class="visual-story__frame visual-story__frame--${index + 1}" data-visual-tilt>
+            <div class="visual-story__media">
+              <img src="${src}" alt="${alt}" loading="lazy" decoding="async" />
+              <span class="visual-story__index">0${index + 1}</span>
+            </div>
+            <figcaption>${label}</figcaption>
+          </figure>
+        `).join('')}
+      </div>
+    </div>
+  `;
+  return section;
+}
+
+function initVisualStories() {
+  const config = VISUAL_STORIES[normalisePath(window.location.pathname)];
+  const footer = document.querySelector('footer');
+  if (!config || !footer || document.querySelector('.visual-story')) return;
+  footer.before(buildVisualStory(config));
+
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+      !window.matchMedia('(hover: hover)').matches) return;
+
+  document.querySelectorAll('[data-visual-tilt]').forEach((frame) => {
+    frame.addEventListener('pointermove', (event) => {
+      const rect = frame.getBoundingClientRect();
+      const x = (event.clientX - rect.left) / rect.width - .5;
+      const y = (event.clientY - rect.top) / rect.height - .5;
+      frame.style.setProperty('--visual-rx', `${(-y * 3).toFixed(2)}deg`);
+      frame.style.setProperty('--visual-ry', `${(x * 4).toFixed(2)}deg`);
+      frame.style.setProperty('--visual-x', `${((x + .5) * 100).toFixed(1)}%`);
+      frame.style.setProperty('--visual-y', `${((y + .5) * 100).toFixed(1)}%`);
+    });
+    frame.addEventListener('pointerleave', () => {
+      frame.style.removeProperty('--visual-rx');
+      frame.style.removeProperty('--visual-ry');
+    });
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initVisualStories, { once: true });
+} else {
+  initVisualStories();
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1151,3 +1151,110 @@ section.border-t::before { content:''; position:absolute; left:50%; top:-1px; wi
   .hero-immersive__image,.signal-scene,.depth-card { transform:none !important; transition:none !important; }
   .hero-immersive__scan,.signal-scene__ring,.signal-scene__beam,.signal-scene__node { animation:none !important; }
 }
+
+
+/* ============================================================
+   VISUAL STORIES — site-wide mission imagery
+   ============================================================ */
+.visual-story {
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 8% 18%, rgba(43,120,255,.09), transparent 26rem),
+    linear-gradient(180deg, rgba(255,255,255,.012), transparent 40%);
+}
+.visual-story__inner {
+  width: min(100% - 2rem, 80rem);
+  margin-inline: auto;
+  padding-block: clamp(5rem, 9vw, 8rem);
+}
+.visual-story__intro {
+  display: grid;
+  grid-template-columns: minmax(0, .9fr) minmax(18rem, .55fr);
+  gap: 1rem 4rem;
+  align-items: end;
+  margin-bottom: clamp(2rem, 5vw, 4.5rem);
+}
+.visual-story__intro .tag { grid-column: 1 / -1; justify-self: start; }
+.visual-story__intro h2 { max-width: 16ch; font-size: clamp(2rem, 4.2vw, 3.8rem); }
+.visual-story__intro > p:last-child { color: rgba(197,203,214,.48); max-width: 36rem; font-size: 1.05rem; }
+.visual-story__grid {
+  display: grid;
+  grid-template-columns: 1.35fr .65fr;
+  grid-template-rows: repeat(2, minmax(12rem, 18rem));
+  gap: 1rem;
+  perspective: 1100px;
+}
+.visual-story__frame {
+  --visual-rx: 0deg;
+  --visual-ry: 0deg;
+  position: relative;
+  min-width: 0;
+  margin: 0;
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: 14px;
+  overflow: hidden;
+  background: #080d16;
+  transform: rotateX(var(--visual-rx)) rotateY(var(--visual-ry));
+  transition: transform .45s var(--ease-out-expo), border-color .3s ease, box-shadow .45s ease;
+}
+.visual-story__frame::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(420px circle at var(--visual-x,50%) var(--visual-y,50%), rgba(86,183,255,.13), transparent 44%);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .3s ease;
+}
+.visual-story__frame:hover {
+  border-color: rgba(86,183,255,.28);
+  box-shadow: 0 28px 80px rgba(0,0,0,.38);
+}
+.visual-story__frame:hover::after { opacity: 1; }
+.visual-story__frame--1 { grid-row: 1 / 3; }
+.visual-story__media { position: absolute; inset: 0; overflow: hidden; }
+.visual-story__media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, transparent 45%, rgba(4,7,13,.86));
+}
+.visual-story__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(.8) contrast(1.08);
+  transition: transform .9s var(--ease-out-expo), filter .5s ease;
+}
+.visual-story__frame:hover img { transform: scale(1.045); filter: saturate(1) contrast(1.06); }
+.visual-story__frame figcaption {
+  position: absolute;
+  z-index: 2;
+  left: 1.25rem;
+  bottom: 1rem;
+  color: rgba(244,246,251,.88);
+  font-size: .76rem;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+.visual-story__index {
+  position: absolute;
+  z-index: 2;
+  right: 1rem;
+  top: 1rem;
+  color: rgba(244,246,251,.38);
+  font-size: .65rem;
+  letter-spacing: .14em;
+  padding: .3rem .45rem;
+  border: 1px solid rgba(255,255,255,.1);
+  background: rgba(4,7,13,.58);
+  backdrop-filter: blur(8px);
+}
+@media (max-width: 760px) {
+  .visual-story__intro { grid-template-columns: 1fr; }
+  .visual-story__grid { grid-template-columns: 1fr; grid-template-rows: 22rem repeat(2, 14rem); }
+  .visual-story__frame--1 { grid-row: auto; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .visual-story__frame, .visual-story__media img { transform: none !important; transition: none !important; }
+}


### PR DESCRIPTION
## Summary
- adds page-specific image narratives to VANTAGE, RAPTOR, AEGIS, SCOUT, Architect, Technology, and Company
- reuses the repository's strongest existing mission assets instead of generic stock imagery
- introduces cinematic crops, numbered frames, captions, responsive layouts, and restrained pointer depth
- preserves lazy loading, touch behavior, and reduced-motion support
- keeps the implementation centralized so individual HTML pages do not accumulate duplicate gallery markup

## Notes
Local shell startup remains unavailable, so this is a draft pending deployment/build preview.