### PR TITLE
Fix: own-vs-rent post shipped unstyled

### DIFF
--- a/blog/2026-07-25-own-vs-rent-ai-small-govcons.html
+++ b/blog/2026-07-25-own-vs-rent-ai-small-govcons.html
@@ -155,5 +155,6 @@
         </div>
       </div>
     </footer>
+    <script type="module" src="../src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Missing ../src/main.js include meant no Tailwind bundle on the new blog post. Fixed and visually verified in the built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)