### PR TITLE
Homepage: brand block in hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,9 +124,15 @@
           <div class="grid gap-14 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,500px)] lg:items-center">
 
             <div class="space-y-8" data-animate>
-              <div class="flex flex-wrap items-center gap-3">
-                <span class="tag">Veteran-Owned SDVOSB</span>
-                <span class="tag">CAGE 179U9</span>
+              <div class="space-y-4">
+                <div class="flex items-center gap-4">
+                  <img src="./assets/Emblem.webp" alt="" aria-hidden="true" class="h-12 w-12" width="558" height="558" />
+                  <p class="text-2xl md:text-3xl font-bold tracking-[0.22em] text-white uppercase">Ceradon <span class="text-[color:var(--ceradon-sky)]">Systems</span></p>
+                </div>
+                <div class="flex flex-wrap items-center gap-3">
+                  <span class="tag">Veteran-Owned SDVOSB</span>
+                  <span class="tag">CAGE 179U9</span>
+                </div>
               </div>
 
               <h1 class="font-bold leading-[1.08] tracking-tight" style="font-size:clamp(2.4rem,4.1vw,3.9rem);max-width:none" data-animate data-delay="100">


### PR DESCRIPTION
Adds emblem + CERADON SYSTEMS wordmark at the top of the hero so the company is identifiable at first glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)