### PR TITLE
Fix hero text readability over background images

### DIFF
--- a/lantern.html
+++ b/lantern.html
@@ -86,7 +86,7 @@
     <main id="main-content">
       <!-- HERO -->
       <section class="relative overflow-hidden border-b border-[color:var(--steel-700)]">
-        <img src="./assets/lantern-atak.webp" alt="Lantern floorplan overlay shown on a tactical map display" class="absolute inset-0 w-full h-full object-cover opacity-25" />
+        <img src="./assets/lantern-atak.webp" alt="Lantern floorplan overlay shown on a tactical map display" class="absolute inset-0 w-full h-full object-cover opacity-[0.16]" />
         <div class="relative mx-auto max-w-7xl px-4 py-24">
           <p class="text-xs uppercase tracking-[0.3em] text-[color:var(--ceradon-blue)] mb-4">Lantern &middot; Alpha</p>
           <h1 class="text-4xl md:text-6xl font-bold text-[color:var(--white)] max-w-4xl leading-tight">One drone goes in. Everybody gets the floorplan.</h1>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -525,8 +525,22 @@ header nav .group.is-open > div.hidden {
   z-index: -2;
 }
 
+/* Readability scrim over hero background images: darkens the text side
+   and the bottom edge so copy stays legible over bright imagery. */
 .hero-splash::after {
-  display: none;
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background:
+    linear-gradient(to right, rgba(4, 7, 13, 0.88) 0%, rgba(4, 7, 13, 0.62) 45%, rgba(4, 7, 13, 0.3) 100%),
+    linear-gradient(to top, rgba(4, 7, 13, 0.72), transparent 45%);
+}
+
+.hero-splash > div {
+  position: relative;
+  z-index: 2;
 }
 
 /* Grid background pattern */

--- a/technology.html
+++ b/technology.html
@@ -130,7 +130,7 @@
 
       <!-- HERO: the thesis -->
       <section class="relative overflow-hidden border-b border-[color:var(--steel-700)]">
-        <img src="./assets/hero-technology.webp" alt="" aria-hidden="true" class="absolute inset-0 w-full h-full object-cover opacity-20" />
+        <img src="./assets/hero-technology.webp" alt="" aria-hidden="true" class="absolute inset-0 w-full h-full object-cover opacity-[0.14]" />
         <div class="absolute inset-0 bg-gradient-to-b from-[#04070d]/40 via-[#04070d]/60 to-[#04070d]" aria-hidden="true"></div>
         <div class="relative mx-auto max-w-7xl px-4 py-24">
           <p class="text-xs uppercase tracking-[0.3em] text-[color:var(--ceradon-blue)] mb-4">Technology &middot; Engineering approach</p>


### PR DESCRIPTION
Gradient scrim on .hero-splash pages + dimmed lantern/technology hero backgrounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)